### PR TITLE
Don't refresh tableau component if browser is background

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13365,6 +13365,11 @@
             "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
             "dev": true
         },
+        "vue-visibility-change": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/vue-visibility-change/-/vue-visibility-change-1.2.1.tgz",
+            "integrity": "sha512-CgnubNhAY+EXqTHba660YY7FRubBuYkSELIlbXBBdgdiM/g5DmgFtLd2XChCqXs56TTfshnlIA900traBZPZQg=="
+        },
         "vuedraggable": {
             "version": "2.23.0",
             "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.23.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "vue-notification": "^1.3.16",
         "vue-property-decorator": "^8.1.0",
         "vue-router": "^3.0.3",
+        "vue-visibility-change": "^1.2.1",
         "vuedraggable": "^2.23.0",
         "vuex": "^3.1.1",
         "vuex-persistedstate": "^2.5.4",

--- a/src/components/Tableau.vue
+++ b/src/components/Tableau.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tableau-container">
+  <div class="tableau-container" v-visibility-change="onVisibilityChanged">
     <div class="dev-tool-bar" v-if="!hideDevToolbar">
       Refresh Interval:
       <input
@@ -17,7 +17,11 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from "vue-property-decorator";
+import visibility from "vue-visibility-change";
 import { Logger } from "../loggers/logger";
+import * as util from "util";
+
+Vue.use(visibility);
 
 @Component
 export default class Tableau extends Vue {
@@ -94,12 +98,22 @@ export default class Tableau extends Vue {
     if (this.refreshTimer) {
       clearInterval(this.refreshTimer);
       Logger.getLogger().debug(`Clear refresh timer. timerId=${this.refreshTimer}`);
+      this.refreshTimer = null;
     }
   }
 
   private onRefreshIntervalChanged(event: any) {
     if (!isNaN(event.target.value)) {
+      this.refreshIntervalInput = event.target.value;
       this.setRefreshTimer(event.target.value);
+    }
+  }
+
+  private onVisibilityChanged(evt: any, hidden: boolean) {
+    if (hidden) {
+      this.clearRefreshTimer();
+    } else {
+      this.setRefreshTimer(this.refreshIntervalInput);
     }
   }
 }

--- a/src/views/SplitedMain.vue
+++ b/src/views/SplitedMain.vue
@@ -4,7 +4,7 @@
       <span v-for="tableauViews in tableauViewsArray" :key="tableauViews.id">
         <splitpanes>
           <span v-for="tableauView in tableauViews" :key="tableauView.id">
-            <Tableau :url="tableauView.url" :refreshInterval="5000" :hideDevToolbar="false" />
+            <Tableau :url="tableauView.url" :refreshInterval="-1" :hideDevToolbar="false" />
           </span>
         </splitpanes>
       </span>


### PR DESCRIPTION
- vue-visibility-change libraryを追加
- Tableauコンポーネントがバックグラウンドにいる場合、データをリフレッシュしないよう変更