### PR TITLE
bootstrap-vue version up:2.0.0-rc.26 -> 2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -963,13 +963,13 @@
             "dev": true
         },
         "@nuxt/opencollective": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.2.2.tgz",
-            "integrity": "sha512-ie50SpS47L+0gLsW4yP23zI/PtjsDRglyozX2G09jeiUazC1AJlGPZo0JUs9iuCDUoIgsDEf66y7/bSfig0BpA==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.3.0.tgz",
+            "integrity": "sha512-Vf09BxCdj1iT2IRqVwX5snaY2WCTkvM0O4cWWSO1ThCFuc4if0Q/nNwAgCxRU0FeYHJ7DdyMUNSdswCLKlVqeg==",
             "requires": {
-                "chalk": "^2.4.1",
-                "consola": "^2.3.0",
-                "node-fetch": "^2.3.0"
+                "chalk": "^2.4.2",
+                "consola": "^2.10.1",
+                "node-fetch": "^2.6.0"
             }
         },
         "@soda/friendly-errors-webpack-plugin": {
@@ -2664,14 +2664,14 @@
             "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
         },
         "bootstrap-vue": {
-            "version": "2.0.0-rc.27",
-            "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.0.0-rc.27.tgz",
-            "integrity": "sha512-gXdpt2IsKbmC3SU0bf/RgldWwgrXK7G47yslOtkk4OA1z6fOzb2orM2vU5L8NCNZQomYax9LapRucv+8PByfdA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.0.2.tgz",
+            "integrity": "sha512-hbGJjc/om9JfVNUFK76dnh+YutlZdZlKbpWw6OE9gHTkmbwstP/KxxELpZZgK/4SYtdxUPt/6W1CvdaeT1bNvQ==",
             "requires": {
-                "@nuxt/opencollective": "^0.2.2",
-                "bootstrap": "^4.3.1",
+                "@nuxt/opencollective": "^0.3.0",
+                "bootstrap": ">=4.3.1 <5.0.0",
                 "popper.js": "^1.15.0",
-                "portal-vue": "^2.1.5",
+                "portal-vue": "^2.1.6",
                 "vue-functional-data-merge": "^3.1.0"
             }
         },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "@browser-bunyan/server-stream": "^1.5.3",
         "axios": "^0.19.0",
-        "bootstrap-vue": "^2.0.0-rc.26",
+        "bootstrap-vue": "^2.0.2",
         "browser-bunyan": "^1.5.3",
         "core-js": "^2.6.5",
         "splitpanes": "^1.14.5",


### PR DESCRIPTION
- bootstrap-vueをバージョンアップ（2.0.0-rc.26 -> 2.0.2）